### PR TITLE
Can't do syn.get on a constructor that hasn't been stored

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # synapseformation
 Client for using Synapse Formation templates.
 
+## Usage
+```
+import synapseclient
+from synapseformation import create
 
+syn = synapseclient.login()
+# Only create entities
+CreateCls = create.SynapseCreation(syn)
+# Only retrieve entities (don't update)
+RetrieveCls = create.SynapseCreation(syn, only_create=False)
+
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ syn = synapseclient.login()
 # Only create entities
 CreateCls = create.SynapseCreation(syn)
 # Only retrieve entities (don't update)
-RetrieveCls = create.SynapseCreation(syn, only_create=False)
+RetrieveCls = create.SynapseCreation(syn, only_get=True)
 ```
 
 ## Contributing

--- a/synapseformation/create.py
+++ b/synapseformation/create.py
@@ -40,8 +40,10 @@ class SynapseCreation:
         Returns:
             Entity
         """
-        body = json.dumps({"parentId": parentid, "entityName": entity_name})
-        entity_obj = self.syn.restPOST("/entity/child", body=body)
+        # This does not recursively look through containers of containers.
+        # You must always specify the parentid of the entity you are
+        # trying to find
+        entity_obj = self.syn.findEntityId(entity_name, parent=parentid)
         new_obj = self.syn.get(entity_obj['id'], downloadFile=False)
         assert concrete_type == new_obj.properties.concreteType, "Different types."  # pylint: disable=line-too-long
         return new_obj

--- a/synapseformation/create.py
+++ b/synapseformation/create.py
@@ -50,7 +50,8 @@ class SynapseCreation:
         elif isinstance(obj, Team):
             obj = self.syn.getTeam(obj.name)
         elif isinstance(obj, Wiki):
-            obj = self.syn.getWiki(obj)
+            # Only gets the root wiki page
+            obj = self.syn.getWiki(obj.ownerId)
         elif isinstance(obj, Evaluation):
             obj = self.syn.getEvaluationByName(obj.name)
         else:

--- a/synapseformation/create.py
+++ b/synapseformation/create.py
@@ -279,7 +279,7 @@ class SynapseCreation:
             challenge = self._create_challenge(**kwargs)
         except SynapseHTTPError as err:
             # Must check for 409 error
-            if err.response.status_code != 409:
+            if err.response.status_code != 400:
                 raise err
             if self.only_create:
                 raise ValueError(f"{str(err)}. To use existing entities, "

--- a/synapseformation/create.py
+++ b/synapseformation/create.py
@@ -47,7 +47,8 @@ class SynapseCreation:
         # TODO: when entity doesn't exist, don't do this get
         new_obj = self.syn.get(entity_obj['id'], downloadFile=False)
         assert concrete_type == new_obj.properties.concreteType, (
-            f"Retrieved '{entity_name}' had type '{new_obj.properties.concreteType}' "
+            f"Retrieved '{entity_name}' had type "
+            f"'{new_obj.properties.concreteType}' "
             f"rather than the expected type '{concrete_type}'."
         )
         return new_obj
@@ -301,11 +302,11 @@ class SynapseCreation:
         try:
             challenge = self._create_challenge(**kwargs)
         except SynapseHTTPError as err:
-            # Must check for 409 error
+            # Must check for 400 error
             if err.response.status_code != 400:
                 raise err
             if self.only_create:
-                raise ValueError(f"{str(err)}. To use existing entities, "
+                raise ValueError(f"{err}. To use existing entities, "
                                  "set only_create to False.")
             challenge = self._get_challenge(kwargs['projectId'])
         self.logger.info("{} Challenge ({})".format(self._update_str,

--- a/synapseformation/create.py
+++ b/synapseformation/create.py
@@ -43,7 +43,10 @@ class SynapseCreation:
         body = json.dumps({"parentId": parentid, "entityName": entity_name})
         entity_obj = self.syn.restPOST("/entity/child", body=body)
         new_obj = self.syn.get(entity_obj['id'], downloadFile=False)
-        assert concrete_type == new_obj.properties.concreteType, "Different types."  # pylint: disable=line-too-long
+        assert concrete_type == new_obj.properties.concreteType, (
+            f"Retrieved '{entity_name}' had type '{new_obj.properties.concreteType}' "
+            f"rather than the expected type '{concrete_type}'."
+        )
         return new_obj
 
     def _get_obj(self, obj: SynapseCls) -> SynapseCls:

--- a/synapseformation/create.py
+++ b/synapseformation/create.py
@@ -15,18 +15,20 @@ SynapseCls = Union[Project, Team, Evaluation, File, Folder, Wiki,
 
 class SynapseCreation:
     """Creates Synapse Features"""
-    def __init__(self, syn: Synapse, only_create: bool = True,
+    def __init__(self, syn: Synapse, only_get: bool = False,
                  logger: Logger = None):
         """
         Args:
             syn: Synapse connection
-            only_create: Only create entities. Default is True, which
-                         means creation will fail if resource already exists.
+            only_get: Only get entities. Default is False, which
+                      means by default, an attempt will be made at
+                      creating an entity.  The creation will fail if
+                      resource already exists.
         """
         self.syn = syn
-        self.only_create = only_create
+        self.only_get = only_get
         self.logger = logger or logging.getLogger(__name__)
-        self._update_str = "Fetched existing" if only_create else "Created"
+        self._update_str = "Created" if only_get else "Fetched existing"
 
     def _find_entity_by_name(self, entity_name: str, parentid: str,
                              concrete_type: str) -> SynapseCls:
@@ -98,9 +100,9 @@ class SynapseCreation:
             # upload an entity that has the same name
             if err.response.status_code != 409:
                 raise err
-            if self.only_create:
+            if not self.only_get:
                 raise ValueError(f"{str(err)}. To use existing entities, "
-                                 "set only_create to False.")
+                                 "set only_get to True.")
             obj = self._get_obj(obj)
         return obj
 
@@ -305,9 +307,9 @@ class SynapseCreation:
             # Must check for 400 error
             if err.response.status_code != 400:
                 raise err
-            if self.only_create:
+            if not self.only_get:
                 raise ValueError(f"{err}. To use existing entities, "
-                                 "set only_create to False.")
+                                 "set only_get to True.")
             challenge = self._get_challenge(kwargs['projectId'])
         self.logger.info("{} Challenge ({})".format(self._update_str,
                                                     challenge['id']))

--- a/synapseformation/create.py
+++ b/synapseformation/create.py
@@ -44,6 +44,7 @@ class SynapseCreation:
         # You must always specify the parentid of the entity you are
         # trying to find
         entity_obj = self.syn.findEntityId(entity_name, parent=parentid)
+        # TODO: when entity doesn't exist, don't do this get
         new_obj = self.syn.get(entity_obj['id'], downloadFile=False)
         assert concrete_type == new_obj.properties.concreteType, (
             f"Retrieved '{entity_name}' had type '{new_obj.properties.concreteType}' "

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -80,7 +80,12 @@ def test__find_by_obj_or_create__get():
         patch_cls_get.assert_called_once_with(entity)
 
 
-@pytest.mark.parametrize("obj", [synapseclient.Project(name="foo")])
+@pytest.mark.parametrize(
+    "obj", [synapseclient.Project(name="foo"),
+            synapseclient.File(path="foo.txt", parentId="syn12345"),
+            synapseclient.Folder(name="foo", parentId="syn12345"),
+            synapseclient.Schema(name="foo", parentId="syn12345")]
+)
 def test__get_obj__entity(obj):
     """Test getting of entities"""
     with patch.object(GET_CLS, "_find_entity_by_name",

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -16,7 +16,7 @@ from synapseformation.create import SynapseCreation
 
 SYN = mock.create_autospec(synapseclient.Synapse)
 CREATE_CLS = SynapseCreation(SYN)
-GET_CLS = SynapseCreation(SYN, only_create=False)
+GET_CLS = SynapseCreation(SYN, only_get=True)
 
 
 def test__find_by_obj_or_create__create():
@@ -40,7 +40,7 @@ def test__find_by_obj_or_create__onlycreate_raise():
     with patch.object(SYN, "store",
                       side_effect=mocked_409) as patch_syn_store,\
          pytest.raises(ValueError, match="foo. To use existing entities, "
-                                         "set only_create to False."):
+                                         "set only_get to True."):
         CREATE_CLS._find_by_obj_or_create(entity)
         patch_syn_store.assert_called_once_with(entity, createOrUpdate=False)
 
@@ -373,14 +373,14 @@ def test_get_or_create_challenge__get():
 
 
 def test_get_or_create_challenge__get_raise():
-    """Tests trying to get a queue when only_create"""
+    """Tests trying to get a queue when only_get"""
     projectid = str(uuid.uuid1())
     teamid = str(uuid.uuid1())
     mocked_400 = SynapseHTTPError("foo", response=Mock(status_code=400))
     with patch.object(CREATE_CLS, "_create_challenge",
                       side_effect=mocked_400),\
          pytest.raises(ValueError, match="foo. To use existing entities, "
-                                         "set only_create to False."):
+                                         "set only_get to True."):
         CREATE_CLS.get_or_create_challenge(participantTeamId=teamid,
                                            projectId=projectid)
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -80,18 +80,17 @@ def test__find_by_obj_or_create__get():
         patch_cls_get.assert_called_once_with(entity)
 
 
-@pytest.mark.parametrize("obj,get_func",
-                         [(synapseclient.Project(name="foo"), "get")])
-def test__get_obj__entity(obj, get_func):
+@pytest.mark.parametrize("obj", [synapseclient.Project(name="foo")])
+def test__get_obj__entity(obj):
     """Test getting of entities"""
-    with patch.object(SYN, get_func, return_value=obj) as patch_get:
+    with patch.object(GET_CLS, "_find_entity_by_name",
+                      return_value=obj) as patch_get:
         return_obj = GET_CLS._get_obj(obj)
-        if isinstance(obj, synapseclient.Project):
-            patch_get.assert_called_once_with(obj, downloadFile=False)
-        elif isinstance(obj, (synapseclient.Team, synapseclient.Evaluation)):
-            patch_get.assert_called_once_with(obj.name)
-        elif isinstance(obj, synapseclient.Wiki):
-            patch_get.assert_called_once_with(obj.ownerId)
+        patch_get.assert_called_once_with(
+            parentid=obj.properties.get("parentId", None),
+            entity_name=obj.name,
+            concrete_type=obj.properties.concreteType)
+        assert obj == return_obj
 
 
 @pytest.mark.parametrize("obj,get_func",

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -105,7 +105,8 @@ def test__find_entity_by_name__invalid():
                              id="syn11111")
     with patch.object(SYN, "findEntityId", return_value=post_return),\
          patch.object(SYN, "get", return_value=obj),\
-         pytest.raises(AssertionError, match="Different types."):
+         pytest.raises(AssertionError,
+                       match="Retrieved .* had type .* rather than .*"):
         GET_CLS._find_entity_by_name(
             parentid="syn12345",
             entity_name="foo.txt",

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -85,8 +85,8 @@ def test__find_entity_by_name__valid():
     post_return = {'id': "syn11111"}
     obj = synapseclient.File(path="foo.txt", parentId="syn12345",
                              id="syn11111")
-    with patch.object(SYN, "restPOST",
-                      return_value=post_return) as patch_post,\
+    with patch.object(SYN, "findEntityId",
+                      return_value=post_return) as patch_find,\
          patch.object(SYN, "get", return_value=obj) as patch_get:
         return_obj = GET_CLS._find_entity_by_name(
             parentid="syn12345",
@@ -94,14 +94,8 @@ def test__find_entity_by_name__valid():
             concrete_type=obj.properties.concreteType
         )
         assert obj == return_obj
-        patch_post.assert_called_once_with(
-            "/entity/child",
-            body=json.dumps({"parentId": "syn12345",
-                             "entityName": "foo.txt"})
-        )
-        patch_get.assert_called_once_with(
-            "syn11111", downloadFile=False
-        )
+        patch_find.assert_called_once_with("foo.txt", parent="syn12345")
+        patch_get.assert_called_once_with("syn11111", downloadFile=False)
 
 
 def test__find_entity_by_name__invalid():
@@ -109,11 +103,10 @@ def test__find_entity_by_name__invalid():
     post_return = {'id': "syn11111"}
     obj = synapseclient.File(path="foo.txt", parentId="syn12345",
                              id="syn11111")
-    with patch.object(SYN, "restPOST",
-                      return_value=post_return) as patch_post,\
-         patch.object(SYN, "get", return_value=obj) as patch_get,\
+    with patch.object(SYN, "findEntityId", return_value=post_return),\
+         patch.object(SYN, "get", return_value=obj),\
          pytest.raises(AssertionError, match="Different types."):
-        return_obj = GET_CLS._find_entity_by_name(
+        GET_CLS._find_entity_by_name(
             parentid="syn12345",
             entity_name="foo.txt",
             concrete_type="Test"


### PR DESCRIPTION
* Must use a rest call to obtain an entity id by name
* Use existing function to get evaluation by name