### PR TITLE
SYNF-9: Add minimal long template

### DIFF
--- a/templates/long.yaml
+++ b/templates/long.yaml
@@ -1,0 +1,18 @@
+# This expanded template is intentionally kept simple.
+# Each resource type is used as few times as possible.
+# Each use should be for testing different edge cases.
+# Edge cases should be described in the resource name.
+
+- name: Test Project - With Folders
+  type: Project
+  children:
+  - name: Test Folder - With Subfolder and One of Many
+    type: Folder
+    children:
+    - name: Test Subfolder - Empty
+      type: Folder
+  - name: Test Folder - Empty and One of Many
+    type: Folder
+
+- name: Test Project - Empty
+  type: Project


### PR DESCRIPTION
## Rationale

- The expanded template is intentionally kept simple. Each resource type is used as few times as possible. Each use should be for testing different edge cases. Edge cases should be described in the resource name. (This is included as a comment in the template as a reminder.)
- I'm avoiding use of YAML anchors and aliases since they're YAML features that aren't specific to our template format. 
- I'm avoiding a deeply nested folder structure because it doesn't really explore new edge cases. 
- I'm including the type in the names (_e.g._ `Test Project ...`) so that it's clear what's what once we work on the short format (see preview of short format below). 
- I avoided putting the minimal template into the `YAML` subfolders in `templates/` because we've decided to use YAML consistently (instead of maintaining both YAML and JSON files). 

## Questions

- Should we move the TREAT-AD templates back to the dedicated templates repository? I was thinking of keeping only the minimal long and short templates in this repo for testing purposes, and PRs that update them will also serve for discussion. 

## Preview of Short Format

Reviewing the short format will come in a future PR. I just wanted to include a preview here in to keep it in mind when suggesting tweaks to the long format, and vice versa. 

```
Test Project - With Folders:
  children:
    Test Folder - With Subfolder and One of Many:
      children:
        Test Subfolder - Empty:
    Test Folder - Empty and One of Many:

Test Project - Empty:
```