### PR TITLE
SYNF-7 Support ACL in client

### DIFF
--- a/synapseformation/client.py
+++ b/synapseformation/client.py
@@ -3,7 +3,7 @@ import synapseclient
 from synapseclient import Synapse
 
 from .create import SynapseCreation
-from . import utils
+from . import create, utils
 
 
 # def expand_config(config: dict) -> dict:
@@ -39,13 +39,6 @@ from . import utils
 #     return config
 
 
-def _add_acl(syn, entity, acl_config):
-    """Adds ACLs to Synapse entity"""
-    for acl in acl_config:
-        syn.setPermissions(entity=entity, principalId=acl['principal_id'],
-                           accessType=acl['access_type'])
-
-
 def _create_synapse_resources(config: dict, creation_cls: SynapseCreation,
                               parentid: str = None):
     """Recursively steps through template and creates synapse resources
@@ -58,7 +51,8 @@ def _create_synapse_resources(config: dict, creation_cls: SynapseCreation,
     """
     if isinstance(config, dict) and config.get('type') == "Project":
         project_ent = creation_cls.get_or_create_project(name=config['name'])
-        _add_acl(creation_cls.syn, project_ent, config.get('acl', []))
+        create._set_acl(syn=creation_cls.syn, entity=project_ent,
+                        acl_config=config.get('acl', []))
         parent_id = project_ent.id
         config['id'] = parent_id
         # Get children if exists
@@ -73,7 +67,8 @@ def _create_synapse_resources(config: dict, creation_cls: SynapseCreation,
             folder_ent = creation_cls.get_or_create_folder(
                 name=folder_name, parentId=parentid
             )
-            _add_acl(creation_cls.syn, folder_ent, folder.get('acl', []))
+            create._set_acl(syn=creation_cls.syn, entity=folder_ent,
+                            acl_config=folder.get('acl', []))
             folder['id'] = folder_ent.id
             # Create nested folders
             children = folder.get('children', [])

--- a/synapseformation/create.py
+++ b/synapseformation/create.py
@@ -316,7 +316,7 @@ class SynapseCreation:
         return challenge
 
 
-def _set_acl(syn: Synapse, entity: Union[Folder, Project],
+def _set_acl(syn: Synapse, entity: Union[File, Folder, Project],
              acl_config: dict):
     """Adds ACLs to Synapse entity
 

--- a/synapseformation/create.py
+++ b/synapseformation/create.py
@@ -314,3 +314,18 @@ class SynapseCreation:
         self.logger.info("{} Challenge ({})".format(self._update_str,
                                                     challenge['id']))
         return challenge
+
+
+def _set_acl(syn: Synapse, entity: Union[Folder, Project],
+             acl_config: dict):
+    """Adds ACLs to Synapse entity
+
+    Args:
+        syn: Synapse connection
+        entity: Synapse Folder or Project
+        acl_config: ACL template json configuration
+
+    """
+    for acl in acl_config:
+        syn.setPermissions(entity=entity, principalId=acl['principal_id'],
+                           accessType=acl['access_type'])

--- a/synapseformation/create.py
+++ b/synapseformation/create.py
@@ -318,7 +318,7 @@ class SynapseCreation:
 
 def _set_acl(syn: Synapse, entity: Union[Folder, Project],
              acl_config: dict):
-    """Adds ACLs to Synapse entity
+    """Sets ACLs to Synapse entity
 
     Args:
         syn: Synapse connection

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,10 +2,10 @@
 Test client
 """
 from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import synapseclient
-from synapseformation import client
+from synapseformation import client, create
 from synapseformation.create import SynapseCreation
 
 
@@ -139,6 +139,31 @@ class TestCreateSynapseResources():
                                              parentid="syn5555")
             patch_create.assert_has_calls([call_1, call_2])
             assert folder_config == expected_config
+
+    def test__create_synapse_resources_project_acl(self):
+        """Test project gets created"""
+        project_config = {
+            'name': 'Test Configuration',
+            'type': 'Project',
+            'acl': ['fake']
+        }
+        expected_config = {
+            'name': 'Test Configuration',
+            'type': 'Project',
+            'id': 'syn12222',
+            'acl': ['fake']
+        }
+        project_ent = synapseclient.Project(id="syn12222")
+        with patch.object(self.create_cls, "get_or_create_project",
+                          return_value=project_ent) as patch_create,\
+             patch.object(create, "_set_acl") as patch_set:
+            client._create_synapse_resources(config=project_config,
+                                             creation_cls=self.create_cls)
+            patch_create.assert_called_once_with(name=project_config['name'])
+            assert project_config == expected_config
+            patch_set.assert_called_once_with(
+                syn=self.create_cls.syn, entity=project_ent,
+                acl_config=['fake'])
 
     def test__create_synapse_resources_recursive(self):
         """Test recursive calls are made"""

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -12,6 +12,7 @@ import pytest
 import synapseclient
 from synapseclient.core.exceptions import SynapseHTTPError
 
+from synapseformation import create
 from synapseformation.create import SynapseCreation
 
 SYN = mock.create_autospec(synapseclient.Synapse)
@@ -399,9 +400,29 @@ def test_get_or_create_challenge__get_raise_404():
 
 def test_get_or_create_challenge__get_raise_missing_param():
     """Tests that a missing parameter will raise an error"""
-    projectid = str(uuid.uuid1())
     teamid = str(uuid.uuid1())
     with pytest.raises(TypeError,
                        match=".*missing 1 required positional argument: "
                              "'projectId'"):
         CREATE_CLS.get_or_create_challenge(participantTeamId=teamid)
+
+
+def test__set_acl():
+    syn = Mock()
+    entity = Mock()
+    acl_config = [
+        {"principal_id": "1111111",
+         "access_type": ["READ", "DOWNLOAD"]},
+        {"principal_id": "2222222",
+         "access_type": ["READ", "DOWNLOAD", "UPDATE"]}
+    ]
+    expected_calls = [
+        mock.call(entity=entity, principalId="1111111",
+                  accessType=["READ", "DOWNLOAD"]),
+        mock.call(entity=entity, principalId="2222222",
+                  accessType=["READ", "DOWNLOAD", "UPDATE"])
+    ]
+    with patch.object(syn, "setPermissions") as patch_set:
+        create._set_acl(syn=syn, entity=entity,
+                        acl_config=acl_config)
+        patch_set.assert_has_calls(expected_calls)


### PR DESCRIPTION
After working on this, I realized the `_create_synapse_resources` can be cleaned up a bit.  This is done in #35 

- [x] Add tests