### PR TITLE
Update treat-ad template & fix recursion limit error

### DIFF
--- a/synapseformation/client.py
+++ b/synapseformation/client.py
@@ -56,6 +56,7 @@ def _create_synapse_resources(config_list: List[dict],
     # Error: entity not specified
     entity = None
     # Must iterate through list to avoid recursion limit issue
+    # This works because every layer in the json is a list
     for config in config_list:
         if isinstance(config, dict) and config.get('type') == "Project":
             entity = creation_cls.get_or_create_project(name=config['name'])

--- a/synapseformation/client.py
+++ b/synapseformation/client.py
@@ -1,4 +1,6 @@
 """Synapse Formation client"""
+from typing import List
+
 import synapseclient
 from synapseclient import Synapse
 
@@ -39,13 +41,13 @@ from . import create, utils
 #     return config
 
 
-def _create_synapse_resources(config: dict, creation_cls: SynapseCreation,
+def _create_synapse_resources(config_lst: List[dict],
+                              creation_cls: SynapseCreation,
                               parentid: str = None):
     """Recursively steps through template and creates synapse resources
 
     Args:
-        syn: Synapse connection
-        config: Synapse Formation template dict
+        config_lst: List of Synapse resources
         creation_cls: SynapseCreation class that can create resources
         parentid: Synapse folder or project id to store entities
     """
@@ -53,41 +55,41 @@ def _create_synapse_resources(config: dict, creation_cls: SynapseCreation,
     # function is called from within the for loop
     # Error: entity not specified
     entity = None
-    if isinstance(config, dict) and config.get('type') == "Project":
-        entity = creation_cls.get_or_create_project(name=config['name'])
-    elif isinstance(config, dict) and config.get('type') == "Folder":
-        entity = creation_cls.get_or_create_folder(
-            name=config['name'], parentId=parentid
-        )
-    elif isinstance(config, dict) and config.get('type') == "Team":
-        team = creation_cls.get_or_create_team(
-            name=config['name'], description=config['description'],
-            canPublicJoin=config['can_public_join']
-        )
-        config['id'] = team.id
-        if config.get("invitations") is not None:
-            for invite in config['invitations']:
-                for member in invite['members']:
-                    user = member.get("principal_id")
-                    email = member.get("email")
-                    creation_cls.syn.invite_to_team(
-                        team=team, user=user, inviteeEmail=email,
-                        message=invite['message']
-                    )
-    else:
-        # Loop through folders and create them
-        for folder_config in config:
-            _create_synapse_resources(folder_config, creation_cls,
-                                      parentid=parentid)
-    if entity is not None:
-        parent_id = entity.id
-        config['id'] = parent_id
-        # Get ACL if exists
-        create._set_acl(syn=creation_cls.syn, entity=entity,
-                        acl_config=config.get('acl', []))
-        children = config.get('children', [])
-        _create_synapse_resources(children, creation_cls,
-                                  parentid=parent_id)
+    # Must iterate through list to avoid recursion limit issue
+    for config in config_lst:
+        if isinstance(config, dict) and config.get('type') == "Project":
+            entity = creation_cls.get_or_create_project(name=config['name'])
+        elif isinstance(config, dict) and config.get('type') == "Folder":
+            entity = creation_cls.get_or_create_folder(
+                name=config['name'], parentId=parentid
+            )
+        elif isinstance(config, dict) and config.get('type') == "Team":
+            team = creation_cls.get_or_create_team(
+                name=config['name'], description=config['description'],
+                canPublicJoin=config['can_public_join']
+            )
+            config['id'] = team.id
+            if config.get("invitations") is not None:
+                for invite in config['invitations']:
+                    for member in invite['members']:
+                        user = member.get("principal_id")
+                        email = member.get("email")
+                        creation_cls.syn.invite_to_team(
+                            team=team, user=user, inviteeEmail=email,
+                            message=invite['message']
+                        )
+        # only entities can have children and ACLs
+        if entity is not None:
+            parent_id = entity.id
+            config['id'] = parent_id
+            # Get ACL if exists
+            create._set_acl(syn=creation_cls.syn, entity=entity,
+                            acl_config=config.get('acl', []))
+            children = config.get('children', None)
+            # implement this to not run into recursion limit
+            if children is not None:
+                _create_synapse_resources(children, creation_cls,
+                                        parentid=parent_id)
 
 
 def create_synapse_resources(template_path: str):
@@ -102,6 +104,5 @@ def create_synapse_resources(template_path: str):
     # full_config = expand_config(config)
     # Recursive function to create resources
     creation_cls = SynapseCreation(syn)
-    for resource in config:
-        _create_synapse_resources(resource, creation_cls)
+    _create_synapse_resources(config_lst=config, creation_cls=creation_cls)
     print(config)

--- a/synapseformation/client.py
+++ b/synapseformation/client.py
@@ -41,13 +41,13 @@ from . import create, utils
 #     return config
 
 
-def _create_synapse_resources(config_lst: List[dict],
+def _create_synapse_resources(config_list: List[dict],
                               creation_cls: SynapseCreation,
                               parentid: str = None):
     """Recursively steps through template and creates synapse resources
 
     Args:
-        config_lst: List of Synapse resources
+        config_list: List of Synapse resources
         creation_cls: SynapseCreation class that can create resources
         parentid: Synapse folder or project id to store entities
     """
@@ -56,7 +56,7 @@ def _create_synapse_resources(config_lst: List[dict],
     # Error: entity not specified
     entity = None
     # Must iterate through list to avoid recursion limit issue
-    for config in config_lst:
+    for config in config_list:
         if isinstance(config, dict) and config.get('type') == "Project":
             entity = creation_cls.get_or_create_project(name=config['name'])
         elif isinstance(config, dict) and config.get('type') == "Folder":
@@ -88,8 +88,9 @@ def _create_synapse_resources(config_lst: List[dict],
             children = config.get('children', None)
             # implement this to not run into recursion limit
             if children is not None:
-                _create_synapse_resources(children, creation_cls,
-                                        parentid=parent_id)
+                _create_synapse_resources(config_list=children,
+                                          creation_cls=creation_cls,
+                                          parentid=parent_id)
 
 
 def create_synapse_resources(template_path: str):
@@ -104,5 +105,5 @@ def create_synapse_resources(template_path: str):
     # full_config = expand_config(config)
     # Recursive function to create resources
     creation_cls = SynapseCreation(syn)
-    _create_synapse_resources(config_lst=config, creation_cls=creation_cls)
+    _create_synapse_resources(config_list=config, creation_cls=creation_cls)
     print(config)

--- a/templates/treat_ad_long.yaml
+++ b/templates/treat_ad_long.yaml
@@ -38,38 +38,65 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: CAPN2
       type: Folder
       children:
@@ -77,38 +104,65 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: CD44
       type: Folder
       children:
@@ -116,37 +170,63 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
     - name: CNN3
       type: Folder
@@ -155,30 +235,52 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
@@ -194,37 +296,63 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
     - name: EPHX2
       type: Folder
@@ -233,37 +361,63 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
     - name: FCER1G
       type: Folder
@@ -272,38 +426,65 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: GPNMB
       type: Folder
       children:
@@ -311,37 +492,63 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
     - name: MDK
       type: Folder
@@ -350,37 +557,63 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
     - name: MSN
       type: Folder
@@ -389,37 +622,63 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
     - name: NDUFS2
       type: Folder
@@ -428,30 +687,52 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
@@ -467,37 +748,63 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
     - name: PRDX1
       type: Folder
@@ -506,37 +813,63 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
     - name: PRDX6
       type: Folder
@@ -545,37 +878,63 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
     - name: RABEP1
       type: Folder
@@ -584,38 +943,65 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: SDC4
       type: Folder
       children:
@@ -623,38 +1009,65 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: SFRP1
       type: Folder
       children:
@@ -662,38 +1075,65 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: SMOC1
       type: Folder
       children:
@@ -701,38 +1141,65 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: SNX32
       type: Folder
       children:
@@ -740,38 +1207,65 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: STX4
       type: Folder
       children:
@@ -779,38 +1273,65 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: SYK
       type: Folder
       children:
@@ -818,38 +1339,65 @@
         type: Folder
         children:
         - name: Antibody_Validation_Data
+          type: Folder
         - name: Assay_Protocols
+          type: Folder
         - name: Assay_Results
+          type: Folder
         - name: Cell_Lines
+          type: Folder
         - name: Chemotypes
+          type: Folder
         - name: Crystal_Structures
+          type: Folder
         - name: Expression_Constructs
+          type: Folder
         - name: Expression_Data
+          type: Folder
         - name: Fragment_Screening_Results
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Protein
+          type: Folder
         - name: Protein_Expression_Methods
+          type: Folder
         - name: TEP
+          type: Folder
       - name: Assay_Core
         type: Folder
         children:
         - name: Assay_Results
+          type: Folder
         - name: Compounds
+          type: Folder
         - name: HTS_Protocols
+          type: Folder
         - name: HTS_Results
+          type: Folder
         - name: Isogenic_Cell_Line
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Off_Target_Potency
+          type: Folder
         - name: Secondary_Screen_Protocols
+          type: Folder
         - name: Secondary_Screen_Result
+          type: Folder
       - name: MedChem_Core
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
   - name: Project_Activities
     type: Folder
     children:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,7 +67,7 @@ class TestCreateSynapseResources():
         """Setting up for each method"""
         self.syn = mock.create_autospec(synapseclient.Synapse)
         self.create_cls = SynapseCreation(self.syn)
-        self.config = {
+        self.config = [{
             'name': 'Test Configuration',
             'type': 'Project',
             'children': [
@@ -82,25 +82,26 @@ class TestCreateSynapseResources():
                     ]
                 }
             ]
-        }
+        }]
 
     def test__create_synapse_resources_project(self):
         """Test project gets created"""
-        project_config = {
-            'name': 'Test Configuration',
+        project_name = 'Test Configuration'
+        project_config = [{
+            'name': project_name,
             'type': 'Project'
-        }
-        expected_config = {
-            'name': 'Test Configuration',
+        }]
+        expected_config = [{
+            'name': project_name,
             'type': 'Project',
             'id': 'syn12222'
-        }
+        }]
         project_ent = synapseclient.Project(id="syn12222")
         with patch.object(self.create_cls, "get_or_create_project",
                           return_value=project_ent) as patch_create:
-            client._create_synapse_resources(config=project_config,
+            client._create_synapse_resources(config_list=project_config,
                                              creation_cls=self.create_cls)
-            patch_create.assert_called_once_with(name=project_config['name'])
+            patch_create.assert_called_once_with(name=project_name)
             assert project_config == expected_config
 
     def test__create_synapse_resources_folder(self):
@@ -134,7 +135,7 @@ class TestCreateSynapseResources():
         with patch.object(self.create_cls, "get_or_create_folder",
                           side_effect=[folder_ent_1,
                                        folder_ent_2]) as patch_create:
-            client._create_synapse_resources(config=folder_config,
+            client._create_synapse_resources(config_list=folder_config,
                                              creation_cls=self.create_cls,
                                              parentid="syn5555")
             patch_create.assert_has_calls([call_1, call_2])
@@ -142,24 +143,25 @@ class TestCreateSynapseResources():
 
     def test__create_synapse_resources_acl(self):
         """Test ACL gets created"""
-        project_config = {
-            'name': 'Test Configuration',
+        project_name = 'Test Configuration'
+        project_config = [{
+            'name': project_name,
             'type': 'Project',
             'acl': ['fake']
-        }
-        expected_config = {
-            'name': 'Test Configuration',
+        }]
+        expected_config = [{
+            'name': project_name,
             'type': 'Project',
             'id': 'syn12222',
             'acl': ['fake']
-        }
+        }]
         project_ent = synapseclient.Project(id="syn12222")
         with patch.object(self.create_cls, "get_or_create_project",
                           return_value=project_ent) as patch_create,\
              patch.object(create, "_set_acl") as patch_set:
-            client._create_synapse_resources(config=project_config,
+            client._create_synapse_resources(config_list=project_config,
                                              creation_cls=self.create_cls)
-            patch_create.assert_called_once_with(name=project_config['name'])
+            patch_create.assert_called_once_with(name=project_name)
             assert project_config == expected_config
             patch_set.assert_called_once_with(
                 syn=self.create_cls.syn, entity=project_ent,
@@ -175,7 +177,7 @@ class TestCreateSynapseResources():
                           return_value=project_ent) as patch_create_proj,\
              patch.object(self.create_cls, "get_or_create_folder",
                           return_value=folder_ent) as patch_create_folder:
-            client._create_synapse_resources(config=self.config,
+            client._create_synapse_resources(config_list=self.config,
                                              creation_cls=self.create_cls)
             patch_create_proj.assert_called_once_with(
                 name="Test Configuration"
@@ -184,33 +186,34 @@ class TestCreateSynapseResources():
 
     def test__create_synapse_resources_team(self):
         """Test team gets created"""
-        team_config = {
+        team_config = [{
             'name': 'Test Configuration',
             'type': 'Team',
             'can_public_join': False,
             'description': 'Test team description'
-        }
-        expected_config = {
+        }]
+        expected_config = [{
             'name': 'Test Configuration',
             'type': 'Team',
             'can_public_join': False,
             'description': 'Test team description',
             'id': '11111'
-        }
+        }]
         team_ent = synapseclient.Team(id="11111")
         with patch.object(self.create_cls, "get_or_create_team",
                           return_value=team_ent) as patch_create:
-            client._create_synapse_resources(config=team_config,
+            client._create_synapse_resources(config_list=team_config,
                                              creation_cls=self.create_cls)
             patch_create.assert_called_once_with(
-                name=team_config['name'], description=team_config['description'],
-                canPublicJoin=team_config['can_public_join']
+                name=team_config[0]['name'],
+                description=team_config[0]['description'],
+                canPublicJoin=team_config[0]['can_public_join']
             )
             assert team_config == expected_config
 
     def test__create_synapse_resources_team_invite(self):
         """Test team members are invited"""
-        team_config = {
+        team_config = [{
             'name': 'Test Configuration',
             'type': 'Team',
             'can_public_join': False,
@@ -224,7 +227,7 @@ class TestCreateSynapseResources():
                     ]
                 }
             ]
-        }
+        }]
         team_ent = synapseclient.Team(id="11111")
         expected_calls = [
             mock.call(team=team_ent, user=3426116, inviteeEmail=None,
@@ -237,6 +240,6 @@ class TestCreateSynapseResources():
                           return_value=team_ent) as patch_create,\
              patch.object(self.create_cls.syn,
                           "invite_to_team") as patch_invite:
-            client._create_synapse_resources(config=team_config,
+            client._create_synapse_resources(config_list=team_config,
                                              creation_cls=self.create_cls)
             patch_invite.assert_has_calls(expected_calls)


### PR DESCRIPTION
* TREAT-AD template:  since this is the expanded format, every leaf node has to have a `type`
* Recursion limit error: The treat-ad template has many leaf nodes, the recursion function was written to traverse to every leaf node which is inefficient and hits the recursion limit error. Instead traverse each layer of the tree by iterating and creating the resources.