### PR TITLE
Author SALAD schema for long SynapseFormation template

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click
 synapseclient==2.3.0
 pyyaml
+schema_salad

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
     entry_points={'console_scripts': ['synapseformation = synapseformation.__main__:cli']},
     install_requires=['click',
                       'synapseclient>=2.0.0',
-                      'pyyaml'],
+                      'pyyaml',
+                      'schema_salad'],
     project_urls={
         "Documentation": "https://github.com/Sage-Bionetworks/synapseformation",
         "Source Code": "https://github.com/Sage-Bionetworks/synapseformation",

--- a/synapseformation/schemas/long.schema.yml
+++ b/synapseformation/schemas/long.schema.yml
@@ -11,7 +11,7 @@ $graph:
     - |
       # SynapseFormation Long Template
 
-      Foobar
+      TBD
       
 
 - name: ResourceRecord
@@ -21,7 +21,7 @@ $graph:
   abstract: true
   fields:
   - name: name
-    doc: "Foo"
+    doc: ""
     type: string?
   - name: id
     doc: "Synapse ID"
@@ -35,10 +35,10 @@ $graph:
   abstract: true
   fields:
   - name: children
-    doc: "Foo"
+    doc: ""
     type: FolderRecord[]?
   - name: acl
-    doc: "Foo"
+    doc: ""
     type: AccessControlListRecord[]?
 
 - name: ProjectRecord
@@ -50,7 +50,7 @@ $graph:
   docParent: "#RootDoc"
   fields:
   - name: type
-    doc: "Foo"
+    doc: ""
     jsonldPredicate: syn:type
     type:
       type: enum
@@ -65,7 +65,7 @@ $graph:
   docParent: "#RootDoc"
   fields:
   - name: type
-    doc: "Foo"
+    doc: ""
     jsonldPredicate: syn:type
     type:
       type: enum
@@ -98,11 +98,11 @@ $graph:
   type: record
   fields:
   - name: principal_id
-    doc: "Foo"
+    doc: ""
     type: int
     jsonldPredicate: syn:principal_id
   - name: access_type
-    doc: "Foo"
+    doc: ""
     type: AccessType[]
 
 - name: InvitedMemberRecord
@@ -111,11 +111,11 @@ $graph:
   type: record
   fields:
   - name: principal_id
-    doc: "Foo"
+    doc: ""
     type: int?
     jsonldPredicate: syn:principal_id
   - name: email
-    doc: "Foo"
+    doc: ""
     type: string?
 
 - name: InvitationsRecord
@@ -124,10 +124,10 @@ $graph:
   type: record
   fields:
   - name: message
-    doc: "Foo"
+    doc: ""
     type: string
   - name: members
-    doc: "Foo"
+    doc: ""
     type: InvitedMemberRecord[]
 
 - name: TeamRecord
@@ -138,18 +138,18 @@ $graph:
   documentRoot: true
   fields:
   - name: type
-    doc: "Foo"
+    doc: ""
     type:
       type: enum
       symbols:
       - Team
     jsonldPredicate: syn:type
   - name: can_public_join
-    doc: "Foo"
+    doc: ""
     type: boolean
   - name: description
-    doc: "Foo"
+    doc: ""
     type: string
   - name: invitations
-    doc: "Foo"
+    doc: ""
     type: InvitationsRecord[]?

--- a/synapseformation/schemas/long.schema.yml
+++ b/synapseformation/schemas/long.schema.yml
@@ -1,0 +1,155 @@
+$base: "https://synapse.org#"
+
+$namespaces:
+  syn: "https://synapse.org#"
+
+$graph:
+
+- name: RootDoc
+  type: documentation
+  doc:
+    - |
+      # SynapseFormation Long Template
+
+      Foobar
+      
+
+- name: ResourceRecord
+  doc: |
+    The abstract base type for a Synapse resource.
+  type: record
+  abstract: true
+  fields:
+  - name: name
+    doc: "Foo"
+    type: string?
+  - name: id
+    doc: "Synapse ID"
+    type: string?
+
+- name: EntityRecord
+  doc: |
+    The abstract base type for a Synapse entity.
+  type: record
+  extends: ResourceRecord
+  abstract: true
+  fields:
+  - name: children
+    doc: "Foo"
+    type: FolderRecord[]?
+  - name: acl
+    doc: "Foo"
+    type: AccessControlListRecord[]?
+
+- name: ProjectRecord
+  doc: |
+    The type for a Synapse project.
+  type: record
+  extends: EntityRecord
+  documentRoot: true
+  docParent: "#RootDoc"
+  fields:
+  - name: type
+    doc: "Foo"
+    jsonldPredicate: syn:type
+    type:
+      type: enum
+      symbols:
+      - Project
+
+- name: FolderRecord
+  doc: |
+    The type for a Synapse folder.
+  type: record
+  extends: EntityRecord
+  docParent: "#RootDoc"
+  fields:
+  - name: type
+    doc: "Foo"
+    jsonldPredicate: syn:type
+    type:
+      type: enum
+      symbols:
+      - Folder
+
+- name: AccessType
+  type: enum
+  symbols:
+  - CREATE
+  - READ
+  - UPDATE
+  - DELETE
+  - CHANGE_PERMISSIONS
+  - DOWNLOAD
+  - UPLOAD
+  - PARTICIPATE
+  - SUBMIT
+  - READ_PRIVATE_SUBMISSION
+  - UPDATE_SUBMISSION
+  - DELETE_SUBMISSION
+  - TEAM_MEMBERSHIP_UPDATE
+  - SEND_MESSAGE
+  - CHANGE_SETTINGS
+  - MODERATE
+
+- name: AccessControlListRecord
+  doc: |
+    The type for a Synapse folder.
+  type: record
+  fields:
+  - name: principal_id
+    doc: "Foo"
+    type: int
+    jsonldPredicate: syn:principal_id
+  - name: access_type
+    doc: "Foo"
+    type: AccessType[]
+
+- name: InvitedMemberRecord
+  doc: |
+    The type for a member being invited to join a Synapse team.
+  type: record
+  fields:
+  - name: principal_id
+    doc: "Foo"
+    type: int?
+    jsonldPredicate: syn:principal_id
+  - name: email
+    doc: "Foo"
+    type: string?
+
+- name: InvitationsRecord
+  doc: |
+    The type for an invitation to join a Synapse team.
+  type: record
+  fields:
+  - name: message
+    doc: "Foo"
+    type: string
+  - name: members
+    doc: "Foo"
+    type: InvitedMemberRecord[]
+
+- name: TeamRecord
+  doc: |
+    The type for a Synapse team.
+  type: record
+  extends: ResourceRecord
+  documentRoot: true
+  fields:
+  - name: type
+    doc: "Foo"
+    type:
+      type: enum
+      symbols:
+      - Team
+    jsonldPredicate: syn:type
+  - name: can_public_join
+    doc: "Foo"
+    type: boolean
+  - name: description
+    doc: "Foo"
+    type: string
+  - name: invitations
+    doc: "Foo"
+    type: InvitationsRecord[]?

--- a/synapseformation/schemas/long.schema.yml
+++ b/synapseformation/schemas/long.schema.yml
@@ -12,7 +12,6 @@ $graph:
       # SynapseFormation Long Template
 
       TBD
-      
 
 - name: ResourceRecord
   doc: |
@@ -72,25 +71,30 @@ $graph:
       symbols:
       - Folder
 
-- name: AccessType
+- name: EntityAccessType
   type: enum
   symbols:
-  - CREATE
-  - READ
-  - UPDATE
-  - DELETE
-  - CHANGE_PERMISSIONS
-  - DOWNLOAD
-  - UPLOAD
-  - PARTICIPATE
-  - SUBMIT
-  - READ_PRIVATE_SUBMISSION
-  - UPDATE_SUBMISSION
-  - DELETE_SUBMISSION
-  - TEAM_MEMBERSHIP_UPDATE
-  - SEND_MESSAGE
-  - CHANGE_SETTINGS
-  - MODERATE
+  - syn:READ
+  - syn:DOWNLOAD
+  - syn:UPDATE
+  - syn:CREATE
+  - syn:DELETE
+  - syn:CHANGE_SETTINGS
+  - syn:MODERATE
+  - syn:CHANGE_PERMISSIONS
+
+- name: QueueAccessType
+  type: enum
+  symbols:
+  - syn:READ
+  - syn:SUBMIT
+  - syn:UPDATE_SUBMISSION
+  - syn:READ_PRIVATE_SUBMISSION
+  - syn:DELETE_SUBMISSION
+  - syn:DELETE
+  - syn:UPDATE
+  - syn:CREATE
+  - syn:CHANGE_PERMISSIONS
 
 - name: AccessControlListRecord
   doc: |
@@ -103,7 +107,7 @@ $graph:
     jsonldPredicate: syn:principal_id
   - name: access_type
     doc: ""
-    type: AccessType[]
+    type: EntityAccessType[]
 
 - name: InvitedMemberRecord
   doc: |

--- a/templates/treat_ad_long.yaml
+++ b/templates/treat_ad_long.yaml
@@ -228,6 +228,7 @@
         - name: Structure_Activity_Relationship
           type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: CNN3
       type: Folder
       children:
@@ -285,10 +286,15 @@
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: CTSH
       type: Folder
       children:
@@ -354,6 +360,7 @@
         - name: Structure_Activity_Relationship
           type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: EPHX2
       type: Folder
       children:
@@ -419,6 +426,7 @@
         - name: Structure_Activity_Relationship
           type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: FCER1G
       type: Folder
       children:
@@ -550,6 +558,7 @@
         - name: Structure_Activity_Relationship
           type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: MDK
       type: Folder
       children:
@@ -615,6 +624,7 @@
         - name: Structure_Activity_Relationship
           type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: MSN
       type: Folder
       children:
@@ -680,6 +690,7 @@
         - name: Structure_Activity_Relationship
           type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: NDUFS2
       type: Folder
       children:
@@ -737,10 +748,15 @@
         type: Folder
         children:
         - name: Chemical_Probe_Data
+          type: Folder
         - name: Chemical_Provenance
+          type: Folder
         - name: Lab_Notebooks
+          type: Folder
         - name: Structure_Activity_Relationship
+          type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: PLEC
       type: Folder
       children:
@@ -806,6 +822,7 @@
         - name: Structure_Activity_Relationship
           type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: PRDX1
       type: Folder
       children:
@@ -871,6 +888,7 @@
         - name: Structure_Activity_Relationship
           type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: PRDX6
       type: Folder
       children:
@@ -936,6 +954,7 @@
         - name: Structure_Activity_Relationship
           type: Folder
       - name: Bioinformatics Core
+        type: Folder
     - name: RABEP1
       type: Folder
       children:


### PR DESCRIPTION
Here's a first draft of the SALAD schema that we can use for validation and documentation generation. I'm still working on making sure that the docs look right, but I was able to get the validation part working (see commands below). In fact, I found a few missing `type: Folder` in the TREAT-AD template thanks to this test. 

```
# Ensure that SALAD schema is valid
❯ schema-salad-tool synapseformation/schemas/long.schema.yml
/Users/bgrande/Repos/synapseformation/.venv/bin/schema-salad-tool Current version: 8.1.20210627200047
Schema `synapseformation/schemas/long.schema.yml` is valid

# Validate test template
❯ schema-salad-tool synapseformation/schemas/long.schema.yml templates/long.yaml
/Users/bgrande/Repos/synapseformation/.venv/bin/schema-salad-tool Current version: 8.1.20210627200047
Document `templates/long.yaml` is valid

# Validate TREAT-AD template
❯ schema-salad-tool synapseformation/schemas/long.schema.yml templates/treat_ad_long.yaml
/Users/bgrande/Repos/synapseformation/.venv/bin/schema-salad-tool Current version: 8.1.20210627200047
Document `templates/treat_ad_long.yaml` is valid
```